### PR TITLE
fixed resume of audio after download and after removing local media files

### DIFF
--- a/AwesomeMedia/Classes/Library/AwesomeMedia.swift
+++ b/AwesomeMedia/Classes/Library/AwesomeMedia.swift
@@ -438,9 +438,13 @@ extension AwesomeMedia {
             return
         }
         
-        if url.absoluteString == lastPlayedUrlString && startPlaying {
-            play()
-            return
+        // compare lastPathComponent of the URLs
+        // because of the differences between web url and downloaded url path
+        if let lastPlayedUrlString = lastPlayedUrlString, let lastPlayedUrl = URL(string: lastPlayedUrlString) {
+            if url.lastPathComponent == lastPlayedUrl.lastPathComponent {
+                play()
+                return
+            }
         }
         
         // we're changing the current streaming media, we shall stop the current one.


### PR DESCRIPTION
comparing lastPathComponent of _url_ and _lastPlayedUrl_
because of the difference in _offline File Path_ and _streaming Url_